### PR TITLE
update typings to be more accurate

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,10 +8,10 @@ namespace xbytes {
 
   type ByteValue = number;
   type ByteString = string;
-  type HybridByte =  ByteValue | ByteString;
+  type HybridByte = ByteValue | ByteString;
 
   interface InternalParsedUnit {
-    iec:  boolean;
+    iec: boolean;
     type: 'b' | 'B';
     bits: boolean;
     byte: boolean;
@@ -36,17 +36,17 @@ namespace xbytes {
   }
 
   interface MainOpts {
-    iec: boolean;
-    bits: boolean;
-    fixed: number;
-    short: boolean;
-    space: boolean;
-    prefixIndex: number;
+    iec?: boolean;
+    bits?: boolean;
+    fixed?: number;
+    short?: boolean;
+    space?: boolean;
+    prefixIndex?: number;
   }
 
   interface ParseByteOpts {
-    iec: boolean;
-    bits: boolean;
+    iec?: boolean;
+    bits?: boolean;
   }
 
   interface HybridByteRelations {
@@ -154,7 +154,7 @@ namespace xbytes {
    * @param options.iec Whether or not to enforce compliance to IEC Standards
    * @param options.bits Whether or not to parse a lower case 'b' as bits
   */
-  function parseSize(stringBytes: ByteString, options: ParseByteOpts): ByteValue;
+  function parseSize(stringBytes: ByteString, options?: ParseByteOpts): ByteValue;
   /**
    * Parse a unit to its components
    * @param unit The unit to parse into its components


### PR DESCRIPTION
Modified the options types to more accurately reflect the
implementation. Option keys were all set as required, which then
required setting every option if you wanted to use any option.

I'm currently using this library in a typescript project but have to use `//@ts-ignore` on calls to `xbytes()` when I want to use options. I only want to send one or two options and don't want to calculate the `parseIndex`, but the current `index.d.ts` file has all of the option keys marked as required.

Thanks for the library it is working well and I prefer the API over the alternatives I tried.