### PR TITLE
Add named exports to built ESM module

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,12 +5,35 @@ const PassThrough = require('stream').PassThrough;
 const DIST_DIR = join(__dirname, 'dist');
 const DIST_LIB = join(DIST_DIR, 'index.js');
 
+const exportedMembers = [
+  'ByteUnitObject',
+  'byteFilter',
+  'createByteParser',
+  'createRelativeSizer',
+  'createSizeParser',
+  'extractBytes',
+  'genericMatcher',
+  'globalByteFilter',
+  'isBytes',
+  'isParsable',
+  'isUnit',
+  'parse',
+  'parseBytes',
+  'parseSize',
+  'parseString',
+  'parseUnit',
+  'relative',
+  'unitMatcher',
+];
+
 function createEsmDist(cb) {
   fs.createReadStream(DIST_LIB)
     .pipe(
       new PassThrough({
         final: function(cb) {
-          this.push('\nexport default xbytes;');
+          this.push('\nexport {\n  ');
+          this.push(exportedMembers.join(',\n  '));
+          this.push(',\n};\nexport default xbytes;\n');
           cb();
         },
       })


### PR DESCRIPTION
This fixes #7 for me, by ensuring everything that's made available on the default export object is also exported as a named export.

I figured this was the least invasive way to make this change.

With this change, the built `.mjs` file passes the test case I listed in #7 (provided you change `type` to `module` in the package.json file):

```javascript
// test.js
import {parseSize} from 'xbytes';

console.log(parseSize);
```

```shell
$ node test.js
[Function: parseSize]
```