### PR TITLE
Fix type references for ESM import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "Parse bytes to human readable sizes (4747) → ('4.75 KB') and vice versa.",
   "main": "dist/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "require": {
+      "default": "./dist/index.js",
+      "types": "./typings/index.d.ts"
+    },
+    "import": {
+      "default": "./dist/index.mjs",
+      "types": "./typings/index.d.ts"
+    }
   },
   "types": "typings/index.d.ts",
   "scripts": {


### PR DESCRIPTION
I've recently changed a project to use ES Module imports, and started encountering the following warning when type-checking:

```
Could not find a declaration file for module 'xbytes'. 'node_modules/xbytes/dist/index.mjs' implicitly has an 'any' type.
  There are types at 'node_modules/xbytes/typings/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'xbytes' library may need to update its package.json or typings.
```

According to https://github.com/microsoft/TypeScript/issues/52363#issuecomment-1659179354, this can be resolved by manually indicating that both exports use the same file for types.